### PR TITLE
修复服务端加载时的崩溃问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ run/
 **/src/generated/**/.cache/
 repo/
 !**/src/**/repo/
+.claude

--- a/src/main/java/com/pasterdream/pasterdreammod/PasterDreamMod.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/PasterDreamMod.java
@@ -1,7 +1,5 @@
 package com.pasterdream.pasterdreammod;
 
-import com.pasterdream.pasterdreammod.client.DyeDreamSkyRenderer;
-import com.pasterdream.pasterdreammod.client.PDClientEvents;
 import com.pasterdream.pasterdreammod.command.PDCommands;
 import com.pasterdream.pasterdreammod.data.PDBlockModelProvider;
 import com.pasterdream.pasterdreammod.data.PDBlockTagProvider;
@@ -110,11 +108,8 @@ public class PasterDreamMod {
         // 在游戏总线上注册指令
         NeoForge.EVENT_BUS.addListener(PDCommands::register);
 
-        // 在游戏总线上注册客户端 Tick 事件（染梦维度环境粒子生成）
-        NeoForge.EVENT_BUS.addListener(PDClientEvents::onClientTick);
-
-        // 在游戏总线上注册染梦维度极光天幕渲染器
-        NeoForge.EVENT_BUS.addListener(DyeDreamSkyRenderer::onRenderLevelStage);
+        // 客户端 Tick 事件和极光天幕渲染器通过 @EventBusSubscriber(Dist.CLIENT)
+        // 在 PDClientEvents 和 DyeDreamSkyRenderer 中自动注册，避免服务端类加载
     }
 
     /**

--- a/src/main/java/com/pasterdream/pasterdreammod/api/dimension/DimensionAPI.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/api/dimension/DimensionAPI.java
@@ -7,10 +7,9 @@ import com.pasterdream.pasterdreammod.api.dimension.gen.DimensionTypeGenerator;
 import com.pasterdream.pasterdreammod.api.dimension.gen.SoundsJsonGenerator;
 import com.pasterdream.pasterdreammod.api.dimension.terrain.StructureTerrainNegotiator;
 import com.pasterdream.pasterdreammod.registry.PDSounds;
-import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
-import net.neoforged.neoforge.client.event.RegisterDimensionSpecialEffectsEvent;
+import net.minecraft.world.level.Level;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -27,8 +26,10 @@ import java.util.function.Supplier;
  *   <li><b>维度实例配置</b>：配置生物群系源、噪声设置、默认方块/流体等</li>
  *   <li><b>JSON 文件自动生成</b>：自动生成 dimension_type 和 dimension 的 JSON 文件</li>
  *   <li><b>ResourceKey 管理</b>：自动创建并返回维度类型和维度的 ResourceKey</li>
- *   <li><b>特殊效果注册</b>：配套的客户端特效注册辅助方法</li>
+ *   <li><b>特殊效果注册</b>：配套的客户端特效注册辅助，直接使用 {@code RegisterDimensionSpecialEffectsEvent}</li>
  * </ul>
+ * <p>
+ * 注意：此类不包含任何客户端专属类型引用，确保服务端兼容。
  * <p>
  * 使用示例：
  * <pre>{@code
@@ -52,7 +53,10 @@ import java.util.function.Supplier;
  * // ====== 在 ClientSetup 中注册特效 ======
  * @SubscribeEvent
  * public static void registerEffects(RegisterDimensionSpecialEffectsEvent event) {
- *     DimensionAPI.registerEffects(event, "dyedream_world", new DimensionSpecialEffects(...));
+ *     ResourceLocation id = ResourceLocation.fromNamespaceAndPath(modId, "dyedream_world");
+ *     event.register(id, new DimensionSpecialEffects(192f, true, SkyType.NORMAL, false, false) {
+ *         // 自定义雾色、天空色...
+ *     });
  * }
  * }</pre>
  */
@@ -78,56 +82,6 @@ public final class DimensionAPI {
      */
     public static DimensionBuilder createDimension(String dimensionName) {
         return new DimensionBuilder(PasterDreamMod.MOD_ID, dimensionName);
-    }
-
-    // ======================== 客户端特效注册 ========================
-
-    /**
-     * 注册维度特殊效果（客户端）
-     * <p>
-     * 对应 dimension_type JSON 中的 {@code "effects"} 字段。
-     * 需要在 {@link RegisterDimensionSpecialEffectsEvent} 中调用。
-     * <p>
-     * 使用示例：
-     * <pre>{@code
-     * // 在 ClientSetup.java 中：
-     * @SubscribeEvent
-     * public static void registerEffects(RegisterDimensionSpecialEffectsEvent event) {
-     *     DimensionAPI.registerEffects(event, "dyedream_world",
-     *             new DimensionSpecialEffects(192.0f, true, SkyType.NORMAL, false, false) {
-     *                 @Override
-     *                 public Vec3 getBrightnessDependentFogColor(Vec3 color, float sunHeight) {
-     *                     return color.multiply(0.94, 0.94, 0.91);
-     *                 }
-     *                 @Override
-     *                 public boolean isFoggyAt(int x, int y) { return false; }
-     *             });
-     * }
-     * }</pre>
-     *
-     * @param event   {@link RegisterDimensionSpecialEffectsEvent}
-     * @param name    维度注册名称（与 {@link #createDimension} 传入的名称一致）
-     * @param effects 自定义 {@link DimensionSpecialEffects} 实例
-     */
-    public static void registerEffects(RegisterDimensionSpecialEffectsEvent event,
-                                        String name,
-                                        DimensionSpecialEffects effects) {
-        ResourceLocation id = ResourceLocation.fromNamespaceAndPath(PasterDreamMod.MOD_ID, name);
-        event.register(id, effects);
-        PasterDreamMod.LOGGER.info("[DimensionAPI] ✅ 已注册维度特效: {}", id);
-    }
-
-    /**
-     * 使用已注册的 {@link DimensionResult} 注册特殊效果
-     *
-     * @param event   {@link RegisterDimensionSpecialEffectsEvent}
-     * @param result  之前由 {@link #createDimension} 返回的结果
-     * @param effects 自定义 {@link DimensionSpecialEffects} 实例
-     */
-    public static void registerEffects(RegisterDimensionSpecialEffectsEvent event,
-                                        DimensionResult result,
-                                        DimensionSpecialEffects effects) {
-        registerEffects(event, result.dimensionName(), effects);
     }
 
     // ======================== 工具方法 ========================

--- a/src/main/java/com/pasterdream/pasterdreammod/api/entity/EntityAPI.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/api/entity/EntityAPI.java
@@ -6,8 +6,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
-import net.neoforged.neoforge.client.event.EntityRenderersEvent;
-import net.neoforged.neoforge.client.event.EntityRenderersEvent.RegisterRenderers;
 import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
@@ -22,6 +20,9 @@ import java.util.function.Supplier;
  * 采用与 {@link com.pasterdream.pasterdreammod.api.block.BlockAPI} 相似的
  * Facade 模式 + Builder 模式设计，覆盖实体注册的完整流程。
  * <p>
+ * 注意：此类不包含任何客户端专属类型引用，确保服务端兼容。
+ * 客户端渲染器注册请直接使用 {@code EntityRenderersEvent.RegisterRenderers} 事件。
+ * <p>
  * 使用示例：
  * <pre>{@code
  * // ====== 在 PDEntities.java 中使用 ======
@@ -34,7 +35,9 @@ import java.util.function.Supplier;
  *     .build();
  *
  * // ====== 在 ClientSetup 中注册渲染器 ======
- * EntityAPI.registerRenderer(event, shadowGolem, ShadowGolemRenderer::new);
+ * EntityResult<ShadowGolemEntity> result = (EntityResult<ShadowGolemEntity>)
+ *     EntityAPI.getEntityResult("shadow_golem");
+ * event.registerEntityRenderer(result.entityType(), ShadowGolemRenderer::new);
  *
  * // ====== 在 PDEntityEvents 中注册属性 ======
  * EntityAPI.registerAttributes(event, shadowGolem);
@@ -79,59 +82,8 @@ public final class EntityAPI {
      * @return {@link EntityBuilder} 实例
      */
     public static EntityBuilder<?> createEntity(String name) {
-        PasterDreamMod.LOGGER.info("[EntityAPI] 🎭 开始创建实体构建器: {}", name);
+        PasterDreamMod.LOGGER.info("[EntityAPI] 开始创建实体构建器: {}", name);
         return new EntityBuilder<>(REGISTRY, PasterDreamMod.MOD_ID, name);
-    }
-
-    // ======================== 渲染器注册 ========================
-
-    /**
-     * 注册实体渲染器（客户端）
-     * <p>
-     * 需要在 {@link RegisterRenderers} 事件中调用。
-     *
-     * @param <T>      实体类型
-     * @param event    {@link RegisterRenderers}
-     * @param result   之前由 {@link #createEntity(String)} 返回的结果
-     * @param provider 实体渲染器提供者（如 {@code ShadowGolemRenderer::new}）
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends Entity> void registerRenderer(
-            RegisterRenderers event,
-            EntityResult<T> result,
-            net.minecraft.client.renderer.entity.EntityRendererProvider<? super T> provider) {
-        PasterDreamMod.LOGGER.info("[EntityAPI] 🎨 注册实体渲染器: {} | entityType={}", result.name(), result.entityType());
-        event.registerEntityRenderer(
-                (EntityType<T>) result.entityType(),
-                provider);
-        PasterDreamMod.LOGGER.info("[EntityAPI] ✅ 已注册实体渲染器: {}", result.name());
-    }
-
-    /**
-     * 按实体名称注册实体渲染器（客户端）
-     * <p>
-     * 便捷重载，自动根据实体名称查找已注册的 {@link EntityResult}。
-     * 需要在 {@link RegisterRenderers} 事件中调用。
-     *
-     * @param <T>        实体类型
-     * @param event      {@link RegisterRenderers}
-     * @param entityName 实体注册名称（与 {@link #createEntity(String)} 传入的名称一致）
-     * @param provider   实体渲染器提供者（如 {@code ShadowGolemRenderer::new}）
-     * @throws IllegalStateException 如果未找到对应的实体注册结果
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends Entity> void registerRenderer(
-            RegisterRenderers event,
-            String entityName,
-            net.minecraft.client.renderer.entity.EntityRendererProvider<? super T> provider) {
-        PasterDreamMod.LOGGER.debug("[EntityAPI] 🔍 按名称查找实体注册结果: {}", entityName);
-        EntityResult<T> result = (EntityResult<T>) ENTITY_CACHE.get(entityName);
-        if (result == null) {
-            PasterDreamMod.LOGGER.error("[EntityAPI] ❌ 未找到实体 [{}] 的注册结果", entityName);
-            throw new IllegalStateException("EntityAPI: 未找到实体 [" + entityName + "] 的注册结果，请确认已调用 createEntity().build()");
-        }
-        PasterDreamMod.LOGGER.debug("[EntityAPI] 找到实体 [{}] 的注册结果: {}", entityName, result);
-        registerRenderer(event, result, provider);
     }
 
     // ======================== 属性注册 ========================

--- a/src/main/java/com/pasterdream/pasterdreammod/api/particle/ParticleAPI.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/api/particle/ParticleAPI.java
@@ -2,12 +2,9 @@ package com.pasterdream.pasterdreammod.api.particle;
 
 import com.pasterdream.pasterdreammod.PasterDreamMod;
 import com.pasterdream.pasterdreammod.api.particle.builder.ParticleBuilder;
-import net.minecraft.client.particle.ParticleEngine;
-import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.Registries;
-import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 import java.util.Collections;
@@ -24,9 +21,11 @@ import java.util.function.Supplier;
  *   <li><b>粒子类型注册</b>：通过 Builder 链式配置粒子属性并注册到 DeferredRegister</li>
  *   <li><b>资源文件自动生成</b>：自动生成 {@code particles/{name}.json} 粒子定义文件</li>
  *   <li><b>纹理元数据生成</b>：自动生成 {@code textures/particle/{name}.json} 纹理描述文件</li>
- *   <li><b>Provider 注册辅助</b>：在客户端便捷注册 {@link ParticleProvider}</li>
  *   <li><b>查询管理</b>：缓存已注册的粒子结果，方便后续查询</li>
  * </ul>
+ * <p>
+ * 注意：此类不包含任何客户端专属类型引用，确保服务端兼容。
+ * 客户端 Provider 注册请直接使用 {@code RegisterParticleProvidersEvent} 事件。
  * <p>
  * 使用示例：
  * <pre>{@code
@@ -40,7 +39,12 @@ import java.util.function.Supplier;
  * // ====== 在 ClientSetup 中注册 Provider ======
  * @SubscribeEvent
  * public static void registerParticles(RegisterParticleProvidersEvent event) {
- *     ParticleAPI.registerProviderSprite(event, "sparkle", SparkleParticle.Provider::new);
+ *     ParticleResult result = ParticleAPI.getParticle("sparkle");
+ *     if (result != null) {
+ *         event.registerSpriteSet(
+ *             (SimpleParticleType) result.particleType(),
+ *             SparkleParticle.Provider::new);
+ *     }
  * }
  *
  * // ====== 查询粒子类型 ======
@@ -86,45 +90,8 @@ public final class ParticleAPI {
      * @return {@link ParticleBuilder} 实例
      */
     public static ParticleBuilder createParticle(String particleName) {
-        PasterDreamMod.LOGGER.info("[ParticleAPI] 🎨 开始创建粒子构建器: {}", particleName);
+        PasterDreamMod.LOGGER.info("[ParticleAPI] 开始创建粒子构建器: {}", particleName);
         return new ParticleBuilder(PasterDreamMod.MOD_ID, particleName);
-    }
-
-    // ======================== Provider 注册辅助 ========================
-
-    /**
-     * 注册粒子 Provider（精灵表模式）
-     * <p>
-     * 适用于使用 {@link net.minecraft.client.particle.SpriteSet} 的粒子，
-     * 如 {@link com.pasterdream.pasterdreammod.client.particle.LifeCrystalParticle.Provider}。
-     * <p>
-     * 需要在 {@link RegisterParticleProvidersEvent} 中调用。
-     * <p>
-     * 使用示例：
-     * <pre>{@code
-     * @SubscribeEvent
-     * public static void registerParticles(RegisterParticleProvidersEvent event) {
-     *     ParticleAPI.registerProviderSprite(event, "meltdream_crystal_particle",
-     *             LifeCrystalParticle.Provider::new);
-     * }
-     * }</pre>
-     *
-     * @param event           {@link RegisterParticleProvidersEvent}
-     * @param particleName    粒子注册名称（与 {@link #createParticle} 传入的名称一致）
-     * @param providerFactory 精灵表到 Provider 的工厂函数（{@link net.minecraft.client.particle.ParticleEngine.SpriteParticleRegistration}）
-     */
-    public static void registerProviderSprite(RegisterParticleProvidersEvent event,
-                                               String particleName,
-                                               ParticleEngine.SpriteParticleRegistration<SimpleParticleType> providerFactory) {
-        ParticleResult result = REGISTERED_PARTICLES.get(particleName);
-        if (result == null) {
-            PasterDreamMod.LOGGER.warn("[ParticleAPI] ⚠️ 未找到粒子 [{}] 的注册记录，跳过 Provider 注册", particleName);
-            return;
-        }
-
-        SimpleParticleType type = (SimpleParticleType) result.particleType();
-        event.registerSpriteSet(type, providerFactory);
-        PasterDreamMod.LOGGER.info("[ParticleAPI] ✅ 已注册粒子 Provider: {} | type={}", particleName, type);
     }
 
     // ======================== 查询方法 ========================

--- a/src/main/java/com/pasterdream/pasterdreammod/client/ClientSetup.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/client/ClientSetup.java
@@ -1,9 +1,10 @@
 package com.pasterdream.pasterdreammod.client;
 
 import com.pasterdream.pasterdreammod.PasterDreamMod;
-import com.pasterdream.pasterdreammod.api.dimension.DimensionAPI;
 import com.pasterdream.pasterdreammod.api.entity.EntityAPI;
+import com.pasterdream.pasterdreammod.api.entity.EntityResult;
 import com.pasterdream.pasterdreammod.api.particle.ParticleAPI;
+import com.pasterdream.pasterdreammod.api.particle.ParticleResult;
 import com.pasterdream.pasterdreammod.client.model.Modelslime;
 import com.pasterdream.pasterdreammod.client.particle.*;
 import com.pasterdream.pasterdreammod.client.renderer.block.DreamAccumulatorBlockRenderer;
@@ -12,13 +13,16 @@ import com.pasterdream.pasterdreammod.client.renderer.block.ShadowChestBlockRend
 import com.pasterdream.pasterdreammod.client.renderer.entity.PinkSlimeRenderer;
 import com.pasterdream.pasterdreammod.client.renderer.entity.ShadowGolemRenderer;
 import com.pasterdream.pasterdreammod.client.screen.ShadowChestScreen;
+import com.pasterdream.pasterdreammod.entity.mob.PinkSlimeEntity;
+import com.pasterdream.pasterdreammod.entity.mob.ShadowGolemEntity;
 import com.pasterdream.pasterdreammod.registry.PDBlockEntities;
-import com.pasterdream.pasterdreammod.registry.PDEntities;
 import com.pasterdream.pasterdreammod.registry.PDMenus;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
+import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
@@ -69,12 +73,20 @@ public class ClientSetup {
         PasterDreamMod.LOGGER.info("[ClientSetup] 注册方块实体渲染器: shadow_chest → ShadowChestBlockRenderer");
 
         // 注册暗影魔像实体渲染器
-        EntityAPI.registerRenderer(event, "shadow_golem", ShadowGolemRenderer::new);
-        PasterDreamMod.LOGGER.info("[ClientSetup] 注册实体渲染器: shadow_golem → ShadowGolemRenderer （GeckoLib）");
+        @SuppressWarnings("unchecked")
+        EntityResult<ShadowGolemEntity> shadowGolem = (EntityResult<ShadowGolemEntity>) EntityAPI.getEntityResult("shadow_golem");
+        if (shadowGolem != null) {
+            event.registerEntityRenderer(shadowGolem.entityType(), ShadowGolemRenderer::new);
+            PasterDreamMod.LOGGER.info("[ClientSetup] 注册实体渲染器: shadow_golem → ShadowGolemRenderer （GeckoLib）");
+        }
 
         // 注册粉色史莱姆实体渲染器
-        EntityAPI.registerRenderer(event, "pink_slime", PinkSlimeRenderer::new);
-        PasterDreamMod.LOGGER.info("[ClientSetup] 注册实体渲染器: pink_slime → PinkSlimeRenderer （原生模型）");
+        @SuppressWarnings("unchecked")
+        EntityResult<PinkSlimeEntity> pinkSlime = (EntityResult<PinkSlimeEntity>) EntityAPI.getEntityResult("pink_slime");
+        if (pinkSlime != null) {
+            event.registerEntityRenderer(pinkSlime.entityType(), PinkSlimeRenderer::new);
+            PasterDreamMod.LOGGER.info("[ClientSetup] 注册实体渲染器: pink_slime → PinkSlimeRenderer （原生模型）");
+        }
     }
 
     /**
@@ -104,7 +116,6 @@ public class ClientSetup {
     /**
      * 注册粒子提供器
      * 在 RegisterParticleProvidersEvent 事件时调用
-     * 使用 ParticleAPI 统一管理 Provider 注册
      *
      * @param event 粒子提供器注册事件
      */
@@ -112,17 +123,33 @@ public class ClientSetup {
     public static void registerParticleProviders(RegisterParticleProvidersEvent event) {
         PasterDreamMod.LOGGER.info("[ClientSetup] 开始注册粒子提供器...");
 
-        ParticleAPI.registerProviderSprite(event, "meltdream_crystal_particle", LifeCrystalParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "dream_ambient_particle", DreamAmbientParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "leaves_particle", LeavesParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "dreamfertiliter_particle", DreamfertiliterFallingParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "calle_particle", CalleParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "silver_particle", SilverParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "crack_0_particle", CrackParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "white_star_particle", WhiteStarParticle.Provider::new);
-        ParticleAPI.registerProviderSprite(event, "snowflake_0_particle", SnowflakeParticle.Provider::new);
+        registerParticleProvider(event, "meltdream_crystal_particle", LifeCrystalParticle.Provider::new);
+        registerParticleProvider(event, "dream_ambient_particle", DreamAmbientParticle.Provider::new);
+        registerParticleProvider(event, "leaves_particle", LeavesParticle.Provider::new);
+        registerParticleProvider(event, "dreamfertiliter_particle", DreamfertiliterFallingParticle.Provider::new);
+        registerParticleProvider(event, "calle_particle", CalleParticle.Provider::new);
+        registerParticleProvider(event, "silver_particle", SilverParticle.Provider::new);
+        registerParticleProvider(event, "crack_0_particle", CrackParticle.Provider::new);
+        registerParticleProvider(event, "white_star_particle", WhiteStarParticle.Provider::new);
+        registerParticleProvider(event, "snowflake_0_particle", SnowflakeParticle.Provider::new);
 
         PasterDreamMod.LOGGER.info("[ClientSetup] 粒子提供器注册完成，共 9 个粒子类型");
+    }
+
+    /**
+     * 注册单个粒子 Provider（从 ParticleAPI 缓存中查找粒子类型）
+     */
+    private static void registerParticleProvider(RegisterParticleProvidersEvent event,
+                                                  String name,
+                                                  net.minecraft.client.particle.ParticleEngine.SpriteParticleRegistration<SimpleParticleType> factory) {
+        ParticleResult result = ParticleAPI.getParticle(name);
+        if (result == null) {
+            PasterDreamMod.LOGGER.warn("[ClientSetup] 未找到粒子 [{}] 的注册记录，跳过 Provider 注册", name);
+            return;
+        }
+        SimpleParticleType type = (SimpleParticleType) result.particleType();
+        event.registerSpriteSet(type, factory);
+        PasterDreamMod.LOGGER.info("[ClientSetup] 已注册粒子 Provider: {} | type={}", name, type);
     }
 
     /** 染梦维度四个群系的 ResourceKey 常量（与 PDClientEvents 保持一致） */
@@ -168,68 +195,63 @@ public class ClientSetup {
      */
     @SubscribeEvent
     public static void registerDimensionSpecialEffects(RegisterDimensionSpecialEffectsEvent event) {
-        DimensionAPI.registerEffects(event, "dyedream_world",
-                new DimensionSpecialEffects(
-                        192.0f,
-                        true,
-                        DimensionSpecialEffects.SkyType.NORMAL,
-                        false,
-                        false
-                ) {
-                    @Override
-                    public Vec3 getBrightnessDependentFogColor(Vec3 fogColor, float sunHeight) {
-                        ResourceKey<Biome> biome = PDClientEvents.currentBiomeKey;
+        ResourceLocation id = ResourceLocation.fromNamespaceAndPath(PasterDreamMod.MOD_ID, "dyedream_world");
+        event.register(id, new DimensionSpecialEffects(
+                192.0f, true, DimensionSpecialEffects.SkyType.NORMAL, false, false
+        ) {
+            @Override
+            public Vec3 getBrightnessDependentFogColor(Vec3 fogColor, float sunHeight) {
+                ResourceKey<Biome> biome = PDClientEvents.currentBiomeKey;
 
-                        Vec3 dayColor, sunsetColor, nightColor;
+                Vec3 dayColor, sunsetColor, nightColor;
 
-                        if (BIOME_DYEDREAM_0.equals(biome)) {
-                            // 温暖平原 — 梦幻粉雾
-                            dayColor = new Vec3(1.0, 0.71, 0.85);
-                            sunsetColor = new Vec3(1.0, 0.56, 0.64);
-                            nightColor = new Vec3(0.29, 0.10, 0.36);
-                        } else if (BIOME_DYEDREAM_1.equals(biome)) {
-                            // 炎热森林 — 翠绿迷雾
-                            dayColor = new Vec3(0.66, 0.90, 0.64);
-                            sunsetColor = new Vec3(0.83, 0.64, 0.45);
-                            nightColor = new Vec3(0.10, 0.23, 0.16);
-                        } else if (BIOME_DYEDREAM_2.equals(biome)) {
-                            // 寒冷冰雪 — 冰蓝极雾
-                            dayColor = new Vec3(0.71, 0.85, 1.0);
-                            sunsetColor = new Vec3(0.64, 0.71, 0.83);
-                            nightColor = new Vec3(0.10, 0.16, 0.36);
-                        } else if (BIOME_DYEDREAM_3.equals(biome)) {
-                            // 温暖海洋 — 海蓝薄雾
-                            dayColor = new Vec3(0.64, 0.83, 0.90);
-                            sunsetColor = new Vec3(0.83, 0.64, 0.64);
-                            nightColor = new Vec3(0.04, 0.16, 0.23);
-                        } else {
-                            // 后备：温暖平原色
-                            dayColor = new Vec3(1.0, 0.71, 0.85);
-                            sunsetColor = new Vec3(1.0, 0.56, 0.64);
-                            nightColor = new Vec3(0.29, 0.10, 0.36);
-                        }
-
-                        return interpolateTriColor(dayColor, sunsetColor, nightColor, sunHeight);
-                    }
-
-                    @Override
-                    @Nullable
-                    public float[] getSunriseColor(float timeOfDay, float partialTick) {
-                        float sunHeight = (float) Math.sin(timeOfDay * 2.0 * Math.PI);
-                        if (sunHeight < -0.1f || sunHeight > 0.2f) return null;
-
-                        float fade = (sunHeight + 0.1f) / 0.3f;
-                        float alpha = (float) Math.sin(fade * Math.PI) * 0.55f;
-
-                        return new float[]{1.0f, 0.41f, 0.71f, alpha};
-                    }
-
-                    @Override
-                    public boolean isFoggyAt(int x, int y) {
-                        return false;
-                    }
+                if (BIOME_DYEDREAM_0.equals(biome)) {
+                    // 温暖平原 — 梦幻粉雾
+                    dayColor = new Vec3(1.0, 0.71, 0.85);
+                    sunsetColor = new Vec3(1.0, 0.56, 0.64);
+                    nightColor = new Vec3(0.29, 0.10, 0.36);
+                } else if (BIOME_DYEDREAM_1.equals(biome)) {
+                    // 炎热森林 — 翠绿迷雾
+                    dayColor = new Vec3(0.66, 0.90, 0.64);
+                    sunsetColor = new Vec3(0.83, 0.64, 0.45);
+                    nightColor = new Vec3(0.10, 0.23, 0.16);
+                } else if (BIOME_DYEDREAM_2.equals(biome)) {
+                    // 寒冷冰雪 — 冰蓝极雾
+                    dayColor = new Vec3(0.71, 0.85, 1.0);
+                    sunsetColor = new Vec3(0.64, 0.71, 0.83);
+                    nightColor = new Vec3(0.10, 0.16, 0.36);
+                } else if (BIOME_DYEDREAM_3.equals(biome)) {
+                    // 温暖海洋 — 海蓝薄雾
+                    dayColor = new Vec3(0.64, 0.83, 0.90);
+                    sunsetColor = new Vec3(0.83, 0.64, 0.64);
+                    nightColor = new Vec3(0.04, 0.16, 0.23);
+                } else {
+                    // 后备：温暖平原色
+                    dayColor = new Vec3(1.0, 0.71, 0.85);
+                    sunsetColor = new Vec3(1.0, 0.56, 0.64);
+                    nightColor = new Vec3(0.29, 0.10, 0.36);
                 }
-        );
+
+                return interpolateTriColor(dayColor, sunsetColor, nightColor, sunHeight);
+            }
+
+            @Override
+            @Nullable
+            public float[] getSunriseColor(float timeOfDay, float partialTick) {
+                float sunHeight = (float) Math.sin(timeOfDay * 2.0 * Math.PI);
+                if (sunHeight < -0.1f || sunHeight > 0.2f) return null;
+
+                float fade = (sunHeight + 0.1f) / 0.3f;
+                float alpha = (float) Math.sin(fade * Math.PI) * 0.55f;
+
+                return new float[]{1.0f, 0.41f, 0.71f, alpha};
+            }
+
+            @Override
+            public boolean isFoggyAt(int x, int y) {
+                return false;
+            }
+        });
+        PasterDreamMod.LOGGER.info("[ClientSetup] 已注册维度特效: {}", id);
     }
 }
-

--- a/src/main/java/com/pasterdream/pasterdreammod/client/DyeDreamSkyRenderer.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/client/DyeDreamSkyRenderer.java
@@ -6,9 +6,13 @@ import com.mojang.blaze3d.vertex.BufferUploader;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.pasterdream.pasterdreammod.PasterDreamMod;
 import com.pasterdream.pasterdreammod.registry.PDDimensions;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 
 /**
@@ -17,7 +21,9 @@ import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
  * 监听 RenderLevelStageEvent.Stage.AFTER_SKY 事件，在天空渲染完成后绘制
  * 梦幻极光带。极光由多层半透明彩色光带组成，随时间正弦波动，
  * 使用粉/紫/青渐变色调，夜晚可见度最高。
+ * 通过 {@link EventBusSubscriber} 自动注册到游戏事件总线，仅在客户端生效。
  */
+@EventBusSubscriber(modid = PasterDreamMod.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
 public class DyeDreamSkyRenderer {
 
     private static final int BAND_COUNT = 5;
@@ -31,6 +37,7 @@ public class DyeDreamSkyRenderer {
      *
      * @param event 渲染阶段事件
      */
+    @SubscribeEvent
     public static void onRenderLevelStage(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_SKY) return;
 

--- a/src/main/java/com/pasterdream/pasterdreammod/client/PDClientEvents.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/client/PDClientEvents.java
@@ -12,7 +12,11 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * 客户端事件处理类
@@ -21,7 +25,9 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
  * 每个生物群系拥有独特的粒子效果，同时染梦树叶和樱花树周围会飘落叶片。
  * <p>
  * 同时管理 {@link ModMusicManager} 的 tick 驱动。
+ * 通过 {@link EventBusSubscriber} 自动注册到游戏事件总线，仅在客户端生效。
  */
+@EventBusSubscriber(modid = PasterDreamMod.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
 public class PDClientEvents {
 
     private static final ResourceKey<Biome> BIOME_DYEDREAM_0 = ResourceKey.create(
@@ -66,6 +72,7 @@ public class PDClientEvents {
      *   <li>在染梦维度中生成群系专属环境粒子和落叶</li>
      * </ol>
      */
+    @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
         Minecraft mc = Minecraft.getInstance();
         if (mc.player == null || mc.level == null) return;

--- a/src/main/java/com/pasterdream/pasterdreammod/client/PDClientItemExtensions.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/client/PDClientItemExtensions.java
@@ -2,6 +2,7 @@ package com.pasterdream.pasterdreammod.client;
 
 import com.pasterdream.pasterdreammod.PasterDreamMod;
 import com.pasterdream.pasterdreammod.client.renderer.item.DreamAccumulatorDisplayItemRenderer;
+import com.pasterdream.pasterdreammod.client.renderer.item.DreamMeterItemRenderer;
 import com.pasterdream.pasterdreammod.client.renderer.item.LifeCrystalDisplayItemRenderer;
 import com.pasterdream.pasterdreammod.client.renderer.item.ShadowChestDisplayItemRenderer;
 import com.pasterdream.pasterdreammod.registry.PDItems;
@@ -36,6 +37,9 @@ public class PDClientItemExtensions {
 
         registerDisplayItem(event, PDItems.SHADOW_CHEST.get(), new ShadowChestDisplayItemRenderer());
         PasterDreamMod.LOGGER.info("[PDClientItemExtensions] 注册显示物品: shadow_chest → ShadowChestDisplayItemRenderer（GeckoLib 3D）");
+
+        registerDisplayItem(event, PDItems.DREAM_METER.get(), new DreamMeterItemRenderer());
+        PasterDreamMod.LOGGER.info("[PDClientItemExtensions] 注册显示物品: dream_meter → DreamMeterItemRenderer（GeckoLib 3D）");
     }
 
     /**

--- a/src/main/java/com/pasterdream/pasterdreammod/item/AbstractGeoDisplayItem.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/item/AbstractGeoDisplayItem.java
@@ -1,6 +1,5 @@
 package com.pasterdream.pasterdreammod.item;
 
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -15,6 +14,10 @@ import software.bernie.geckolib.util.GeckoLibUtil;
  * 封装所有使用 GeoItem + BlockItem 的显示物品的公共逻辑，
  * 统一动画注册和实例缓存管理。
  * 客户端渲染器扩展通过 RegisterClientExtensionsEvent 单独注册。
+ * <p>
+ * 注意：该类及其子类不能直接引用客户端专属类（如 BlockEntityWithoutLevelRenderer），
+ * 否则专用服务端加载时会触发 ClassNotFoundException。
+ * 客户端渲染由 {@code client.PDClientItemExtensions} 统一注册。
  */
 public abstract class AbstractGeoDisplayItem extends BlockItem implements GeoItem {
 
@@ -51,13 +54,6 @@ public abstract class AbstractGeoDisplayItem extends BlockItem implements GeoIte
     public final AnimatableInstanceCache getAnimatableInstanceCache() {
         return this.cache;
     }
-
-    /**
-     * 创建自定义渲染器
-     *
-     * @return BlockEntityWithoutLevelRenderer 实例
-     */
-    protected abstract BlockEntityWithoutLevelRenderer createRenderer();
 
     /**
      * 获取动画控制器名称

--- a/src/main/java/com/pasterdream/pasterdreammod/item/DreamAccumulatorDisplayItem.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/item/DreamAccumulatorDisplayItem.java
@@ -1,17 +1,12 @@
 package com.pasterdream.pasterdreammod.item;
 
-import com.pasterdream.pasterdreammod.client.renderer.item.DreamAccumulatorDisplayItemRenderer;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.level.block.Block;
 import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 
 /**
  * 蓄梦池显示物品 (Dream Accumulator Display Item)
- * 用于手持时渲染 GeckoLib 动画模型
- *
- * 原模组使用 MCreator 生成的 DisplayItem 系统，
- * 这里重新实现为 NeoForge 1.21.1 兼容版本
+ * 用于手持时渲染 GeckoLab 动画模型，渲染器通过 RegisterClientExtensionsEvent 注册。
  */
 public class DreamAccumulatorDisplayItem extends AbstractGeoDisplayItem {
 
@@ -23,16 +18,6 @@ public class DreamAccumulatorDisplayItem extends AbstractGeoDisplayItem {
      */
     public DreamAccumulatorDisplayItem(Block block, Properties properties) {
         super(block, properties);
-    }
-
-    /**
-     * 创建自定义渲染器
-     *
-     * @return DreamAccumulatorDisplayItemRenderer 实例
-     */
-    @Override
-    protected BlockEntityWithoutLevelRenderer createRenderer() {
-        return new DreamAccumulatorDisplayItemRenderer();
     }
 
     /**

--- a/src/main/java/com/pasterdream/pasterdreammod/item/DreamMeterItem.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/item/DreamMeterItem.java
@@ -1,11 +1,8 @@
 package com.pasterdream.pasterdreammod.item;
 
-import com.pasterdream.pasterdreammod.client.renderer.item.DreamMeterItemRenderer;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.Rarity;
-import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import software.bernie.geckolib.animatable.GeoItem;
 import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.animation.AnimatableManager;
@@ -14,14 +11,12 @@ import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.animation.RawAnimation;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
-import java.util.function.Consumer;
-
 /**
  * 忆梦魔导透镜 (Dream Meter)
  * 使用 GeckoLib 实现完整 3D 手持模型渲染
  * 包含空闲旋转动画，在 GUI、第一人称、第三人称中均显示 3D 模型
+ * 渲染器通过 RegisterClientExtensionsEvent 注册。
  */
-@SuppressWarnings("removal")
 public class DreamMeterItem extends Item implements GeoItem {
 
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
@@ -31,19 +26,6 @@ public class DreamMeterItem extends Item implements GeoItem {
     public DreamMeterItem() {
         super(new Item.Properties().stacksTo(1).rarity(Rarity.COMMON));
 }
-
-    @Override
-    public void initializeClient(Consumer<IClientItemExtensions> consumer) {
-        super.initializeClient(consumer);
-        consumer.accept(new IClientItemExtensions() {
-            private final BlockEntityWithoutLevelRenderer renderer = new DreamMeterItemRenderer();
-
-            @Override
-            public BlockEntityWithoutLevelRenderer getCustomRenderer() {
-                return renderer;
-            }
-        });
-    }
 
     public void getTransformType(ItemDisplayContext type) {
         this.transformType = type;

--- a/src/main/java/com/pasterdream/pasterdreammod/item/LifeCrystalDisplayItem.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/item/LifeCrystalDisplayItem.java
@@ -1,15 +1,13 @@
 package com.pasterdream.pasterdreammod.item;
 
-import com.pasterdream.pasterdreammod.client.renderer.item.LifeCrystalDisplayItemRenderer;
 import com.pasterdream.pasterdreammod.registry.PDBlocks;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.Item;
 import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 
 /**
  * 生命水晶显示物品
- * 使用 GeoItem 实现 3D 物品渲染
+ * 使用 GeoItem 实现 3D 物品渲染，渲染器通过 RegisterClientExtensionsEvent 注册。
  */
 public class LifeCrystalDisplayItem extends AbstractGeoDisplayItem {
 
@@ -20,16 +18,6 @@ public class LifeCrystalDisplayItem extends AbstractGeoDisplayItem {
      */
     public LifeCrystalDisplayItem(Item.Properties properties) {
         super(PDBlocks.LIFE_CRYSTAL.get(), properties);
-    }
-
-    /**
-     * 创建自定义渲染器
-     *
-     * @return LifeCrystalDisplayItemRenderer 实例
-     */
-    @Override
-    protected BlockEntityWithoutLevelRenderer createRenderer() {
-        return new LifeCrystalDisplayItemRenderer();
     }
 
     /**

--- a/src/main/java/com/pasterdream/pasterdreammod/item/ShadowChestDisplayItem.java
+++ b/src/main/java/com/pasterdream/pasterdreammod/item/ShadowChestDisplayItem.java
@@ -1,15 +1,13 @@
 package com.pasterdream.pasterdreammod.item;
 
-import com.pasterdream.pasterdreammod.client.renderer.item.ShadowChestDisplayItemRenderer;
 import com.pasterdream.pasterdreammod.registry.PDBlocks;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.Item;
 import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 
 /**
  * 暗影箱显示物品
- * 使用 GeoItem 实现 3D 物品渲染
+ * 使用 GeoItem 实现 3D 物品渲染，渲染器通过 RegisterClientExtensionsEvent 注册。
  */
 public class ShadowChestDisplayItem extends AbstractGeoDisplayItem {
 
@@ -20,16 +18,6 @@ public class ShadowChestDisplayItem extends AbstractGeoDisplayItem {
      */
     public ShadowChestDisplayItem(Item.Properties properties) {
         super(PDBlocks.SHADOW_CHEST.get(), properties);
-    }
-
-    /**
-     * 创建自定义渲染器
-     *
-     * @return ShadowChestDisplayItemRenderer 实例
-     */
-    @Override
-    protected BlockEntityWithoutLevelRenderer createRenderer() {
-        return new ShadowChestDisplayItemRenderer();
     }
 
     /**


### PR DESCRIPTION
#本PR修复了NeoForge 1.21.1上专用服务器启动崩溃问题，该问题是由客户端独有类引用在服务器端被加载引起的。

## 问题概述

NeoForge 1.21.1 专用服务端启动时崩溃，原因是有多个类在非客户端包中直接引用了客户端专属类（`BlockEntityWithoutLevelRenderer`、`ClientLevel` 等），被 NeoForge 的 `RuntimeDistCleaner` 类加载拦截器捕获并抛出 `RuntimeException`。

## 崩溃链（按修复顺序）

| 阶段 | 错误 | 触发点 | 根因 |
|------|------|--------|------|
| 1 | `BlockEntityWithoutLevelRenderer` | Item 类及其基类的 `import` + 方法签名 | 4 个 Item 类 + 基类在类层级引用客户端渲染器类 |
| 2 | `ClientLevel` | `ParticleAPI` / `EntityAPI` / `DimensionAPI` 的 `import` | 3 个 API 类混入了客户端事件/类型引用 |
| 3 | `ClientLevel` | `PasterDreamMod` 构造函数中的方法引用 | 主类构造函数直接引用 `PDClientEvents` 和 `DyeDreamSkyRenderer` |

---

## 修改清单（13 个文件）

### 一、Item 类 — 删除死代码 + 移除客户端引用

**核心原则**：创建渲染器的死代码 `createRenderer()` 从未被调用。真实的渲染器绑定已在 `PDClientItemExtensions`（`@EventBusSubscriber(Dist.CLIENT)`）通过 NeoForge 推荐的 `RegisterClientExtensionsEvent` 完成。

| 文件 | 删除项 | 保留项 |
|------|--------|--------|
| `item/AbstractGeoDisplayItem.java` | `import BEWLR`<br>`createRenderer()` 抽象方法 | 所有原始 Javadoc、构造函数、`GeoItem` 实现 |
| `item/ShadowChestDisplayItem.java` | `import BEWLR` + `import Renderer`<br>`createRenderer()` | 所有原始 Javadoc、构造函数 |
| `item/LifeCrystalDisplayItem.java` | 同上 | 同上 |
| `item/DreamAccumulatorDisplayItem.java` | 同上 | 同上 |
| `item/DreamMeterItem.java` | `import BEWLR` + `import IClientItemExtensions`<br>`initializeClient()`（已弃用 API） | 所有原始 Javadoc、GeckoLib 动画逻辑 |
| `client/PDClientItemExtensions.java` | — | **新增** `DreamMeterItemRenderer` 注册，接管原 `initializeClient()` 功能 |

### 二、API 类 — 移除跨层客户端引用

**核心原则**：`api/` 包中的类会被服务端加载，不能包含任何客户端类型引用。客户端专用方法（`registerRenderer`、`registerProviderSprite`、`registerEffects`）已移除，功能直接内联到 `ClientSetup`。

| 文件 | 删除项 |
|------|--------|
| `api/entity/EntityAPI.java` | `import EntityRenderersEvent` / `EntityRendererProvider`<br>`registerRenderer()` x2 |
| `api/particle/ParticleAPI.java` | `import ParticleEngine` / `ParticleProvider` / `RegisterParticleProvidersEvent`<br>`registerProviderSprite()` |
| `api/dimension/DimensionAPI.java` | `import DimensionSpecialEffects` / `RegisterDimensionSpecialEffectsEvent`<br>`registerEffects()` x2 |

### 三、客户端事件 — 从主构造器分离

**核心原则**：模组主类构造函数中的方法引用（`NeoForge.EVENT_BUS.addListener(ClientClass::method)`）会在类加载时触发客户端类解析。应使用 `@EventBusSubscriber(Dist.CLIENT)` 自注册。

| 文件 | 修改 |
|------|------|
| `PasterDreamMod.java` | 移除 `import PDClientEvents` / `DyeDreamSkyRenderer`<br>移除 2 行 `NeoForge.EVENT_BUS.addListener()` |
| `client/PDClientEvents.java` | 新增 `@EventBusSubscriber(modid, Dist.CLIENT, bus = GAME)` + `@SubscribeEvent` |
| `client/DyeDreamSkyRenderer.java` | 同上 |

### 四、ClientSetup — 客户端注册内联

| 文件 | 修改 |
|------|------|
| `client/ClientSetup.java` | 实体渲染器 → 直接调用 `event.registerEntityRenderer()`<br>粒子 Provider → 新增本地辅助方法 `registerParticleProvider()`<br>维度特效 → 直接调用 `event.register()`<br>保留所有原始行内注释和 Javadoc |

---

## 客户端功能等价性验证

| 原实现 | 新实现 | 等价性 |
|--------|--------|--------|
| `DreamMeterItem.initializeClient()` 设置 `IClientItemExtensions` | `PDClientItemExtensions.registerClientExtensions()` 中 `event.registerItem()` | 等价，均设置 `getCustomRenderer()` |
| `EntityAPI.registerRenderer(event, name, provider)` | `event.registerEntityRenderer(result.entityType(), provider)` | 直接调用，行为一致 |
| `ParticleAPI.registerProviderSprite(event, name, factory)` | `event.registerSpriteSet(type, factory)` | 直接调用，行为一致 |
| `DimensionAPI.registerEffects(event, name, effects)` | `event.register(id, effects)` | 直接调用，行为一致 |
| 构造函数手动注册客户端监听器 | `@EventBusSubscriber(Dist.CLIENT, bus = GAME)` | NeoForge 推荐模式，语义等价 |

---

## 架构改进

修复后的分层清晰度：

```
服务端安全区（可在 DEDICATED_SERVER 加载）：
├── PasterDreamMod.java          — 仅注册服务端安全的 DeferredRegister
├── registry/*.java              — 无客户端类型引用
├── item/*.java                  — 无客户端导入，渲染由 client 包负责
├── api/entity/EntityAPI.java    — 纯服务端 API（注册、缓存、查询）
├── api/particle/ParticleAPI.java
└── api/dimension/DimensionAPI.java

客户端专属区（仅 Dist.CLIENT 加载）：
├── client/ClientSetup.java           — @EventBusSubscriber(Dist.CLIENT)
├── client/PDClientItemExtensions.java — @EventBusSubscriber(Dist.CLIENT)
├── client/PDClientEvents.java        — @EventBusSubscriber(Dist.CLIENT, bus = GAME)
├── client/DyeDreamSkyRenderer.java   — @EventBusSubscriber(Dist.CLIENT, bus = GAME)
├── client/renderer/*.java
├── client/particle/*.java
├── client/model/*.java
└── client/screen/*.java
```

已通过本地客户端/服务端测试

Related to #1